### PR TITLE
fix: escape dashes at the start of the line

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -87,13 +87,14 @@ export async function getUserAuthToken(attempt = 0) {
 function processBlockContent(content: string, preferredDateFormat: string) {
     const reg = new RegExp(/timestamp:\|([0-9]+)\|/i)
     if (content !== undefined) {
-        return content.replace(reg, function (match, timestamp) {
+        return content
+            .replace(/\n(\s*)-/sm, '\n$1\\-')
+            .replace(reg, function (match, timestamp) {
             try {
                 return format(new Date(parseInt(timestamp)), preferredDateFormat)
             } catch (e) {
                 return ""
             }
-
         })
     } else {
         return content


### PR DESCRIPTION
Logseq parses content to see if there are Markdown lists. These would normally be used to create child blocks. By escaping the dashes we make sure the parser does not parse the lists as child blocks.

Made this a draft, because it still needs some testing.